### PR TITLE
Update User Table fields to have character limits

### DIFF
--- a/backend/src/app/models/user.py
+++ b/backend/src/app/models/user.py
@@ -12,7 +12,7 @@ class User(Base):
     id = Column(Integer, primary_key=True, index=True)
     email = Column(String(254), unique=True, index=True, nullable=False)
     username = Column(String(50), unique=True, index=True, nullable=False)
-    password_hash = Column(String(255), nullable=False)
+    password_hash = Column(String(512), nullable=False)
     account_disabled = Column(Boolean, default=False) 
     created_at = Column(DateTime(timezone=True), server_default=func.now())
 

--- a/backend/src/app/models/user.py
+++ b/backend/src/app/models/user.py
@@ -10,9 +10,9 @@ class User(Base):
     __tablename__ = "users"
 
     id = Column(Integer, primary_key=True, index=True)
-    email = Column(String, unique=True, index=True, nullable=False)
-    username = Column(String, unique=True, index=True, nullable=False)
-    password_hash = Column(String, nullable=False)
+    email = Column(String(254), unique=True, index=True, nullable=False)
+    username = Column(String(50), unique=True, index=True, nullable=False)
+    password_hash = Column(String(255), nullable=False)
     account_disabled = Column(Boolean, default=False) 
     created_at = Column(DateTime(timezone=True), server_default=func.now())
 


### PR DESCRIPTION
Closes #35

Added character limits to User model fields:
- email: 254 chars
- username: 50 chars
- password_hash: 255 chars