### PR TITLE
Issue #49 | Add CRUD operations for Conversations DB Model

### DIFF
--- a/backend/src/app/models/crud.py
+++ b/backend/src/app/models/crud.py
@@ -1,5 +1,9 @@
+from sqlalchemy import or_
 from sqlalchemy.orm import Session
+
+from app.models.conversations import Conversation
 from app.models.user import User
+from app.schemas.conversation import ConversationCreate
 from app.schemas.user import UserCreate, UserUpdate
 from app.core.auth import hash_password
 
@@ -46,4 +50,59 @@ def disable_user(db: Session, user: User) -> User:
 
 def delete_user(db: Session, user: User) -> None:
     db.delete(user)
+    db.commit()
+
+
+# CONVERSATION CRUD operations
+def _canonical_user_pair(user_a_id: int, user_b_id: int) -> tuple[int, int]:
+    return tuple(sorted((user_a_id, user_b_id)))
+
+
+def create_conversation(db: Session, data: ConversationCreate) -> Conversation:
+    user_one_id, user_two_id = _canonical_user_pair(data.user_one_id, data.user_two_id)
+    db_conversation = Conversation(
+        listing_id=data.listing_id,
+        user_one_id=user_one_id,
+        user_two_id=user_two_id,
+    )
+    db.add(db_conversation)
+    db.commit()
+    db.refresh(db_conversation)
+    return db_conversation
+
+
+def get_conversation_by_id(db: Session, conversation_id: int) -> Conversation | None:
+    return db.query(Conversation).filter(Conversation.id == conversation_id).first()
+
+
+def get_conversation_by_listing_and_users(
+    db: Session, listing_id: int, user_a_id: int, user_b_id: int
+) -> Conversation | None:
+    user_one_id, user_two_id = _canonical_user_pair(user_a_id, user_b_id)
+    return (
+        db.query(Conversation)
+        .filter(
+            Conversation.listing_id == listing_id,
+            Conversation.user_one_id == user_one_id,
+            Conversation.user_two_id == user_two_id,
+        )
+        .first()
+    )
+
+
+def list_conversations_for_user(db: Session, user_id: int) -> list[Conversation]:
+    return (
+        db.query(Conversation)
+        .filter(
+            or_(
+                Conversation.user_one_id == user_id,
+                Conversation.user_two_id == user_id,
+            )
+        )
+        .all()
+    )
+
+
+def delete_conversation(db: Session, conversation: Conversation) -> None:
+    db.delete(conversation)
     db.commit()


### PR DESCRIPTION
Add create, get-by-id, get-by-listing-and-users, list-for-user, and delete. Canonicalize user id order so inserts satisfy user_one_id < user_two_id.

The or_ import is for SQL boolean OR operations.