### PR TITLE
Theme footer and add quick links

### DIFF
--- a/frontend/src/components/Footer.tsx
+++ b/frontend/src/components/Footer.tsx
@@ -1,11 +1,15 @@
+import Link from "next/link";
 
 export default function Footer() {
   return (
-    <footer className="bg-gray-800 text-white py-4 mt-auto">
-      <div className="container mx-auto text-center">
-        <p>
-          &copy; {new Date().getFullYear()} SubLease. All rights reserved.
-        </p>
+    <footer className="mt-auto border-t bg-background py-6 text-sm text-muted-foreground">
+      <div className="container mx-auto flex flex-col items-center justify-between gap-3 px-4 md:flex-row">
+        <p>&copy; {new Date().getFullYear()} SubLease</p>
+        <nav className="flex gap-4">
+          <Link href="/about" className="hover:text-foreground">About</Link>
+          <Link href="/list" className="hover:text-foreground">List your place</Link>
+          <Link href="/signin" className="hover:text-foreground">Sign in</Link>
+        </nav>
       </div>
     </footer>
   );


### PR DESCRIPTION
## Summary
- Footer was using hardcoded `bg-gray-800` / `text-white`, so it ignored light/dark mode.
- Switched to `bg-background` + `border-t` + `text-muted-foreground` so it follows the theme.
- Added About / List your place / Sign in links.