### PR TITLE
Add about page

### DIFF
--- a/frontend/src/app/about/page.tsx
+++ b/frontend/src/app/about/page.tsx
@@ -1,0 +1,11 @@
+export default function About() {
+	return (
+		<main>
+			<h1>About SubLease</h1>
+			<p>
+				SubLease is a small project to help college students find and post
+				short-term housing near their campus.
+			</p>
+		</main>
+	);
+}


### PR DESCRIPTION
## Summary
- Adds a simple `/about` page so the footer link no longer 404s.
- Bare `<main>` since the root layout already wraps Navbar and Footer.