### PR TITLE
Add listing detail page stub

### DIFF
--- a/frontend/src/app/listings/[id]/page.tsx
+++ b/frontend/src/app/listings/[id]/page.tsx
@@ -1,0 +1,14 @@
+type Props = {
+	params: Promise<{ id: string }>;
+};
+
+export default async function Listing({ params }: Props) {
+	const { id } = await params;
+
+	return (
+		<main>
+			<h1>Listing #{id}</h1>
+			<p>Details for this listing will go here once the API is wired up.</p>
+		</main>
+	);
+}


### PR DESCRIPTION
## Summary
- Adds a `/listings/[id]` route so cards can link to a detail page later.
- Just a stub for now, will fill in once the backend listings endpoint is wired up.