### PR TITLE
Add 404 page

### DIFF
--- a/frontend/src/app/not-found.tsx
+++ b/frontend/src/app/not-found.tsx
@@ -1,0 +1,11 @@
+import Link from "next/link";
+
+export default function NotFound() {
+	return (
+		<main>
+			<h1>Page not found</h1>
+			<p>That page doesn&apos;t exist.</p>
+			<Link href="/">Back to home</Link>
+		</main>
+	);
+}


### PR DESCRIPTION
## Summary
- Adds a `not-found.tsx` so bad URLs show a simple 404 instead of the default Next error page.
- Includes a link back to the home page.