### PR TITLE
Add web manifest

### DIFF
--- a/frontend/src/app/manifest.ts
+++ b/frontend/src/app/manifest.ts
@@ -1,0 +1,13 @@
+import type { MetadataRoute } from "next";
+
+export default function manifest(): MetadataRoute.Manifest {
+	return {
+		name: "SubLease",
+		short_name: "SubLease",
+		description: "Find your perfect student sublease",
+		start_url: "/",
+		display: "standalone",
+		background_color: "#ffffff",
+		theme_color: "#ffffff",
+	};
+}


### PR DESCRIPTION
Generates manifest.webmanifest at /manifest with name, theme color, and start URL so the site works as an installable PWA-style app.