### PR TITLE
Add loading state for listings route

### DIFF
--- a/frontend/src/app/(main)/listings/loading.tsx
+++ b/frontend/src/app/(main)/listings/loading.tsx
@@ -1,0 +1,7 @@
+export default function Loading() {
+	return (
+		<main className="container mx-auto flex-1 px-4 py-8">
+			<p className="text-sm text-muted-foreground">Loading listings...</p>
+		</main>
+	);
+}


### PR DESCRIPTION
Shows a 'Loading listings...' message while the listings page is suspending. Lighter than the global loading state since it's scoped to /listings.