### PR TITLE
reset password form

### DIFF
--- a/frontend/src/app/(auth)/reset-password/page.tsx
+++ b/frontend/src/app/(auth)/reset-password/page.tsx
@@ -1,0 +1,9 @@
+import { ResetPasswordForm } from "@/components/reset-password-form";
+
+export default function ResetPasswordPage() {
+  return (
+    <div className="w-full max-w-sm">
+      <ResetPasswordForm />
+    </div>
+  );
+}

--- a/frontend/src/components/Reset-password-form.tsx
+++ b/frontend/src/components/Reset-password-form.tsx
@@ -1,0 +1,183 @@
+"use client";
+
+import { useState } from "react";
+import { useSearchParams, useRouter } from "next/navigation";
+import { z } from "zod";
+import { Controller, useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  Field,
+  FieldError,
+  FieldGroup,
+  FieldLabel,
+} from "@/components/ui/field";
+import { Input } from "@/components/ui/input";
+import { cn } from "@/lib/utils";
+import { API_BASE_URL } from "@/lib/api";
+
+const formSchema = z
+  .object({
+    new_password: z
+      .string()
+      .min(8, "Password must be at least 8 characters."),
+    confirm_password: z
+      .string()
+      .min(8, "Password must be at least 8 characters."),
+  })
+  .refine((data) => data.new_password === data.confirm_password, {
+    message: "Passwords do not match.",
+    path: ["confirm_password"],
+  });
+
+type ResetPasswordValues = z.infer<typeof formSchema>;
+
+export function ResetPasswordForm({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const token = searchParams.get("token");
+  const [isLoading, setIsLoading] = useState(false);
+
+  const form = useForm<ResetPasswordValues>({
+    resolver: zodResolver(formSchema),
+    defaultValues: {
+      new_password: "",
+      confirm_password: "",
+    },
+  });
+
+  async function onSubmit(data: ResetPasswordValues) {
+    if (!token) return;
+    setIsLoading(true);
+
+    try {
+      const res = await fetch(`${API_BASE_URL}/api/v1/auth/reset_password`, {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          token,
+          new_password: data.new_password,
+        }),
+      });
+
+      if (!res.ok) {
+        const errorData = await res.json().catch(() => ({}));
+        toast.error(
+          "Reset failed: " + (errorData?.detail || "Unknown error")
+        );
+        setIsLoading(false);
+        return;
+      }
+
+      toast.success("Password reset successful. Redirecting to sign in...");
+      router.push("/signin");
+    } catch {
+      toast.error("An error occurred. Please try again.");
+      setIsLoading(false);
+    }
+  }
+
+  if (!token) {
+    return (
+      <div className={cn("flex flex-col gap-6", className)} {...props}>
+        <Card>
+          <CardHeader>
+            <CardTitle>Reset Password</CardTitle>
+            <CardDescription>Reset your account password.</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <p className="text-sm text-muted-foreground">
+              Invalid or missing reset token. Request a new link.
+            </p>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  return (
+    <div className={cn("flex flex-col gap-6", className)} {...props}>
+      <Card>
+        <CardHeader>
+          <CardTitle>Reset Password</CardTitle>
+          <CardDescription>Enter your new password below.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <form id="form-reset-password" onSubmit={form.handleSubmit(onSubmit)}>
+            <FieldGroup>
+              <Controller
+                name="new_password"
+                control={form.control}
+                render={({ field, fieldState }) => (
+                  <Field data-invalid={fieldState.invalid}>
+                    <FieldLabel htmlFor="form-reset-password">
+                      New Password
+                    </FieldLabel>
+                    <Input
+                      {...field}
+                      id="form-reset-password"
+                      aria-invalid={fieldState.invalid}
+                      type="password"
+                      placeholder="••••••••"
+                      autoComplete="new-password"
+                    />
+                    {fieldState.invalid && (
+                      <FieldError errors={[fieldState.error]} />
+                    )}
+                  </Field>
+                )}
+              />
+              <Controller
+                name="confirm_password"
+                control={form.control}
+                render={({ field, fieldState }) => (
+                  <Field data-invalid={fieldState.invalid}>
+                    <FieldLabel htmlFor="form-confirm-password">
+                      Confirm Password
+                    </FieldLabel>
+                    <Input
+                      {...field}
+                      id="form-confirm-password"
+                      aria-invalid={fieldState.invalid}
+                      type="password"
+                      placeholder="••••••••"
+                      autoComplete="new-password"
+                    />
+                    {fieldState.invalid && (
+                      <FieldError errors={[fieldState.error]} />
+                    )}
+                  </Field>
+                )}
+              />
+            </FieldGroup>
+          </form>
+        </CardContent>
+        <CardFooter>
+          <Button
+            type="submit"
+            form="form-reset-password"
+            disabled={isLoading}
+            className="w-full"
+          >
+            {isLoading ? "Resetting..." : "Reset Password"}
+          </Button>
+        </CardFooter>
+      </Card>
+    </div>
+  );
+}

--- a/frontend/src/components/reset-password-form.tsx
+++ b/frontend/src/components/reset-password-form.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import Link from "next/link";
 import { useSearchParams, useRouter } from "next/navigation";
 import { z } from "zod";
 import { Controller, useForm } from "react-hook-form";
@@ -24,7 +25,7 @@ import {
 } from "@/components/ui/field";
 import { Input } from "@/components/ui/input";
 import { cn } from "@/lib/utils";
-import { API_BASE_URL } from "@/lib/api";
+import { API_BASE_URL, readApiErrorMessage } from "@/lib/api";
 
 const formSchema = z
   .object({
@@ -76,10 +77,8 @@ export function ResetPasswordForm({
       });
 
       if (!res.ok) {
-        const errorData = await res.json().catch(() => ({}));
-        toast.error(
-          "Reset failed: " + (errorData?.detail || "Unknown error")
-        );
+        const message = await readApiErrorMessage(res) ?? "Unknown error";
+        toast.error("Reset failed: " + message);
         setIsLoading(false);
         return;
       }
@@ -102,7 +101,14 @@ export function ResetPasswordForm({
           </CardHeader>
           <CardContent>
             <p className="text-sm text-muted-foreground">
-              Invalid or missing reset token. Request a new link.
+              Invalid or missing reset token.{" "}
+              <Link
+                href="/forgot-password"
+                className="font-medium text-foreground underline underline-offset-4"
+              >
+                Request a new link
+              </Link>
+              .
             </p>
           </CardContent>
         </Card>
@@ -125,12 +131,12 @@ export function ResetPasswordForm({
                 control={form.control}
                 render={({ field, fieldState }) => (
                   <Field data-invalid={fieldState.invalid}>
-                    <FieldLabel htmlFor="form-reset-password">
+                    <FieldLabel htmlFor="reset-new-password">
                       New Password
                     </FieldLabel>
                     <Input
                       {...field}
-                      id="form-reset-password"
+                      id="reset-new-password"
                       aria-invalid={fieldState.invalid}
                       type="password"
                       placeholder="••••••••"


### PR DESCRIPTION
## Testing instructions

Since real email delivery isn't set up yet, you can test the flow manually:

1. Backend running, frontend running
2. Visit /forgot-password and submit a registered account's email
3. Open dev tools → Network tab → click the forgot_password request → Response tab. Copy the `reset_token` value (only returned in dev mode)
4. Visit /reset-password?token=<paste_token_here>
5. Submit a new password (8+ chars). You'll be redirected to /signin
6. Sign in with the new password to confirm it worked

If you visit /reset-password without a token, you'll see the "Invalid or missing reset token" state, as expected.

Real email delivery (SendGrid/Resend) is out of scope for this PR — flagged as a follow-up issue.