### PR TITLE
Wire message host button into listing detail

### DIFF
--- a/backend/src/app/api/v1/routes.py
+++ b/backend/src/app/api/v1/routes.py
@@ -6,7 +6,6 @@ from app.routes.listings import router as listings_router
 from app.routes.map import router as map_router
 from app.routes.profile import router as profile_router
 from app.routes.users import router as users_router
-from app.routes.profile import router as profile_router
 
 api_router = APIRouter(prefix="/api/v1")
 api_router.include_router(auth_router)
@@ -15,4 +14,3 @@ api_router.include_router(listings_router)
 api_router.include_router(map_router)
 api_router.include_router(profile_router)
 api_router.include_router(users_router)
-api_router.include_router(profile_router)

--- a/frontend/src/app/(main)/listings/[id]/page.tsx
+++ b/frontend/src/app/(main)/listings/[id]/page.tsx
@@ -3,10 +3,9 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 import type { Metadata } from "next";
 import { ArrowLeft, Calendar, MapPin, Star } from "lucide-react";
-import { buttonVariants } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
+import { MessageHostButton } from "@/components/MessageHostButton";
 import { getBrowseListingById } from "@/lib/listings";
-import { cn } from "@/lib/utils";
 
 type Props = { params: Promise<{ id: string }> };
 
@@ -136,15 +135,11 @@ export default async function ListingDetailPage({ params }: Props) {
 							<span className="text-base font-normal text-muted-foreground"> / month</span>
 						</p>
 						<p className="mt-1 text-sm text-muted-foreground capitalize">{listing.room_type}</p>
-						<Link
-							href="/list"
-							className={cn(
-								buttonVariants({ variant: "default", size: "default" }),
-								"mt-6 w-full justify-center rounded-xl",
-							)}
-						>
-							Contact host
-						</Link>
+						<MessageHostButton
+							listingId={listing.id}
+							hostId={listing.host_id}
+							className="mt-6 w-full justify-center rounded-xl"
+						/>
 						<p className="mt-3 text-center text-xs text-muted-foreground">You won&apos;t be charged yet.</p>
 					</Card>
 				</div>

--- a/frontend/src/components/MessageHostButton.tsx
+++ b/frontend/src/components/MessageHostButton.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { API_BASE_URL, ACCESS_TOKEN_KEY, readApiErrorMessage } from "@/lib/api";
+
+type Props = {
+	listingId: number;
+	hostId: number;
+	className?: string;
+};
+
+export function MessageHostButton({ listingId, hostId, className }: Props) {
+	const router = useRouter();
+	const [busy, setBusy] = useState(false);
+
+	async function handle() {
+		const token = localStorage.getItem(ACCESS_TOKEN_KEY);
+		if (!token) {
+			toast.error("Sign in to message a host");
+			router.push("/signin");
+			return;
+		}
+
+		setBusy(true);
+		const res = await fetch(`${API_BASE_URL}/api/v1/conversations/`, {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Authorization: `Bearer ${token}`,
+			},
+			body: JSON.stringify({
+				listing_id: listingId,
+				other_user_id: hostId,
+			}),
+		});
+		setBusy(false);
+
+		if (!res.ok) {
+			const msg = (await readApiErrorMessage(res)) || res.statusText;
+			toast.error("Could not start conversation: " + msg);
+			return;
+		}
+
+		router.push("/messages");
+	}
+
+	return (
+		<Button type="button" onClick={handle} disabled={busy} className={className}>
+			{busy ? "Starting..." : "Message host"}
+		</Button>
+	);
+}


### PR DESCRIPTION
## Summary
- Adds a `MessageHostButton` client component that POSTs to `/api/v1/conversations/` with the listing's id and host id, then routes to `/messages`.
- Replaces the placeholder "Contact host" link on `/listings/[id]` (which was pointing at `/list`) with the new button.
- Falls back to `/signin` when the user has no token.

Closes the loop between listings and the messages page that landed earlier.