### PR TITLE
Fetch featured listings on home page

### DIFF
--- a/frontend/src/app/(main)/page.tsx
+++ b/frontend/src/app/(main)/page.tsx
@@ -2,22 +2,34 @@ import Hero from "@/components/home/Hero";
 import Features from "@/components/home/features";
 import CtaBanner from "@/components/home/cta-banner";
 import { ListingCard } from "@/components/ListingCard";
-import { MOCK_BROWSE_LISTINGS } from "@/lib/listings";
+import { fetchBrowseListings, type BrowseListing } from "@/lib/listings";
 
-const featuredListings = MOCK_BROWSE_LISTINGS.slice(0, 4);
+export default async function Home() {
+  let featuredListings: BrowseListing[] = [];
+  try {
+    const listings = await fetchBrowseListings();
+    featuredListings = listings.slice(0, 4);
+  } catch (e) {
+    console.error("home featured fetch failed", e);
+  }
 
-export default function Home() {
   return (
     <main className="flex-1">
       <Hero />
       <Features />
       <section className="container mx-auto px-4 py-12">
         <h2 className="mb-6 text-2xl font-semibold">Available subleases</h2>
-        <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
-          {featuredListings.map((listing) => (
-            <ListingCard key={listing.id} listing={listing} />
-          ))}
-        </div>
+        {featuredListings.length === 0 ? (
+          <p className="text-sm text-muted-foreground">
+            No listings to show right now.
+          </p>
+        ) : (
+          <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+            {featuredListings.map((listing) => (
+              <ListingCard key={listing.id} listing={listing} />
+            ))}
+          </div>
+        )}
       </section>
       <CtaBanner />
     </main>

--- a/frontend/src/app/(main)/page.tsx
+++ b/frontend/src/app/(main)/page.tsx
@@ -6,11 +6,12 @@ import { fetchBrowseListings, type BrowseListing } from "@/lib/listings";
 
 export default async function Home() {
   let featuredListings: BrowseListing[] = [];
+  let loadFailed = false;
   try {
-    const listings = await fetchBrowseListings();
-    featuredListings = listings.slice(0, 4);
+    featuredListings = await fetchBrowseListings({ limit: 4 });
   } catch (e) {
     console.error("home featured fetch failed", e);
+    loadFailed = true;
   }
 
   return (
@@ -19,9 +20,13 @@ export default async function Home() {
       <Features />
       <section className="container mx-auto px-4 py-12">
         <h2 className="mb-6 text-2xl font-semibold">Available subleases</h2>
-        {featuredListings.length === 0 ? (
+        {loadFailed ? (
           <p className="text-sm text-muted-foreground">
-            No listings to show right now.
+            Could not load listings right now. Please try again later.
+          </p>
+        ) : featuredListings.length === 0 ? (
+          <p className="text-sm text-muted-foreground">
+            No listings yet. Check back soon.
           </p>
         ) : (
           <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">

--- a/frontend/src/lib/listings.ts
+++ b/frontend/src/lib/listings.ts
@@ -325,8 +325,17 @@ export function toBrowseListing(l: Listing): BrowseListing {
 	};
 }
 
-export async function fetchBrowseListings(): Promise<BrowseListing[]> {
-	const res = await fetch(`${API_BASE_URL}/api/v1/listings/?limit=100`);
+type FetchBrowseOptions = {
+	limit?: number;
+};
+
+export async function fetchBrowseListings(
+	options: FetchBrowseOptions = {},
+): Promise<BrowseListing[]> {
+	const limit = options.limit ?? 100;
+	const init: RequestInit =
+		typeof window === "undefined" ? { next: { revalidate: 30 } } : {};
+	const res = await fetch(`${API_BASE_URL}/api/v1/listings/?limit=${limit}`, init);
 	if (!res.ok) {
 		throw new Error("Failed to load listings");
 	}


### PR DESCRIPTION
Replaces the mock slice on the homepage with a real fetch of /listings/. Falls back to a 'no listings' message if the request fails.