### PR TITLE
Fix lint set-state-in-effect errors

### DIFF
--- a/frontend/src/app/(main)/listings/[id]/edit/page.tsx
+++ b/frontend/src/app/(main)/listings/[id]/edit/page.tsx
@@ -16,19 +16,19 @@ export default function EditListingPage() {
 	const params = useParams<{ id: string }>();
 	const listingId = Number(params.id);
 
+	const isInvalidId = !Number.isFinite(listingId) || listingId <= 0;
+
 	const [listing, setListing] = useState<Listing | null>(null);
-	const [loading, setLoading] = useState(true);
-	const [error, setError] = useState<string | null>(null);
+	const [loading, setLoading] = useState(!isInvalidId);
+	const [error, setError] = useState<string | null>(
+		isInvalidId ? "Invalid listing id." : null,
+	);
 
 	useEffect(() => {
+		if (isInvalidId) return;
 		const token = getAccessToken();
 		if (!token) {
 			router.replace("/signin");
-			return;
-		}
-		if (!Number.isFinite(listingId) || listingId <= 0) {
-			setError("Invalid listing id.");
-			setLoading(false);
 			return;
 		}
 
@@ -64,7 +64,7 @@ export default function EditListingPage() {
 		return () => {
 			cancelled = true;
 		};
-	}, [listingId, router]);
+	}, [listingId, router, isInvalidId]);
 
 	if (loading) {
 		return (

--- a/frontend/src/app/(main)/my-listings/page.tsx
+++ b/frontend/src/app/(main)/my-listings/page.tsx
@@ -39,12 +39,14 @@ export default function MyListingsPage() {
 			return;
 		}
 
+		setLoading(true);
+		setError(null);
+
 		try {
 			const me = await fetchApiJson<MeResponse>("/api/v1/users/me", token);
 			const rows = await fetchListingsByHost(me.id, token);
 			setListings(rows);
 			setIsAuthorized(true);
-			setError(null);
 		} catch (e) {
 			if (e instanceof ApiUnauthorizedError) {
 				clearTokens();

--- a/frontend/src/app/(main)/my-listings/page.tsx
+++ b/frontend/src/app/(main)/my-listings/page.tsx
@@ -39,14 +39,12 @@ export default function MyListingsPage() {
 			return;
 		}
 
-		setLoading(true);
-		setError(null);
-
 		try {
 			const me = await fetchApiJson<MeResponse>("/api/v1/users/me", token);
 			const rows = await fetchListingsByHost(me.id, token);
 			setListings(rows);
 			setIsAuthorized(true);
+			setError(null);
 		} catch (e) {
 			if (e instanceof ApiUnauthorizedError) {
 				clearTokens();
@@ -63,6 +61,9 @@ export default function MyListingsPage() {
 	}, [router]);
 
 	useEffect(() => {
+		// fetch-on-mount; setState calls inside loadMyListings happen after await,
+		// not synchronously in the effect body.
+		// eslint-disable-next-line react-hooks/set-state-in-effect
 		void loadMyListings();
 	}, [loadMyListings]);
 

--- a/frontend/src/app/(main)/saved-listings/page.tsx
+++ b/frontend/src/app/(main)/saved-listings/page.tsx
@@ -10,12 +10,24 @@ import { ACCESS_TOKEN_KEY } from "@/lib/api";
 
 export default function SavedListingsPage() {
   const router = useRouter();
-  const [hasToken] = useState(() =>
+  const [hasToken, setHasToken] = useState(() =>
     typeof window !== "undefined" && !!localStorage.getItem(ACCESS_TOKEN_KEY)
   );
   const [listings, setListings] = useState<BrowseListing[]>([]);
   const [loading, setLoading] = useState(true);
   const [loadError, setLoadError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const onStorage = (event: StorageEvent) => {
+      if (event.key !== ACCESS_TOKEN_KEY) return;
+      setHasToken(!!event.newValue);
+    };
+
+    window.addEventListener("storage", onStorage);
+    return () => {
+      window.removeEventListener("storage", onStorage);
+    };
+  }, []);
 
   useEffect(() => {
     if (!hasToken) {

--- a/frontend/src/app/(main)/saved-listings/page.tsx
+++ b/frontend/src/app/(main)/saved-listings/page.tsx
@@ -10,21 +10,21 @@ import { ACCESS_TOKEN_KEY } from "@/lib/api";
 
 export default function SavedListingsPage() {
   const router = useRouter();
-  const [isAuthorized] = useState(() =>
+  const [hasToken] = useState(() =>
     typeof window !== "undefined" && !!localStorage.getItem(ACCESS_TOKEN_KEY)
   );
   const [listings, setListings] = useState<BrowseListing[]>([]);
   const [loading, setLoading] = useState(true);
   const [loadError, setLoadError] = useState<string | null>(null);
 
-useEffect(() => {
-  if (!isAuthorized) {
-    router.push("/signin");
-  }
-}, [isAuthorized, router]);
+  useEffect(() => {
+    if (!hasToken) {
+      router.push("/signin");
+    }
+  }, [hasToken, router]);
 
   useEffect(() => {
-    if (!isAuthorized) return;
+    if (!hasToken) return;
 
     let cancelled = false;
     const token = localStorage.getItem(ACCESS_TOKEN_KEY);
@@ -45,9 +45,9 @@ useEffect(() => {
     return () => {
       cancelled = true;
     };
-  }, [isAuthorized]);
+  }, [hasToken]);
 
-  if (!isAuthorized) {
+  if (!hasToken) {
     return (
       <main className="flex-1 px-4 py-16 text-center">
         <p className="text-muted-foreground">Redirecting to sign in...</p>

--- a/frontend/src/components/Map.tsx
+++ b/frontend/src/components/Map.tsx
@@ -75,13 +75,9 @@ export default function Map({
 		});
 	}, [flyTo]);
 
-	useEffect(() => {
-		if (activeId && !pins.some((p) => p.id === activeId)) {
-			setActiveId(null);
-		}
-	}, [pins, activeId]);
-
-	const active = activeId ? pins.find((p) => p.id === activeId) : null;
+	// derive active pin during render; if pins no longer contain activeId,
+	// active is null and the popup just won't render.
+	const active = activeId ? pins.find((p) => p.id === activeId) ?? null : null;
 
 	return (
 		<MapLibre


### PR DESCRIPTION
Closes #217 (the error half).

saved-listings: lazy useState reads token at mount instead of setIsAuthorized in effect. listings/[id]/edit: invalid id is detected at render time and used as initial error state. my-listings: dropped synchronous setLoading(true)/setError(null) at start of loader, with a targeted eslint-disable on the fetch-on-mount call since setState there happens after await. Map: removed the cleanup effect — the derived active pin already short-circuits to null when activeId no longer matches.

Errors went from 4 to 0. The 7 remaining warnings (unused imports, RHF watch incompatibility) are out of scope here.