### PR TITLE
Issue #224

### DIFF
--- a/backend/src/app/api/v1/routes.py
+++ b/backend/src/app/api/v1/routes.py
@@ -5,6 +5,7 @@ from app.routes.conversations import router as conversations_router
 from app.routes.listings import router as listings_router
 from app.routes.map import router as map_router
 from app.routes.profile import router as profile_router
+from app.routes.saved_listings import router as saved_listings_router
 from app.routes.users import router as users_router
 
 api_router = APIRouter(prefix="/api/v1")
@@ -13,4 +14,5 @@ api_router.include_router(conversations_router)
 api_router.include_router(listings_router)
 api_router.include_router(map_router)
 api_router.include_router(profile_router)
+api_router.include_router(saved_listings_router)
 api_router.include_router(users_router)

--- a/backend/src/app/models/saved_listing.py
+++ b/backend/src/app/models/saved_listing.py
@@ -1,0 +1,16 @@
+from sqlalchemy import Column, DateTime, ForeignKey, Integer, PrimaryKeyConstraint
+from sqlalchemy.sql import func
+
+from app.core.database import Base
+
+
+class SavedListing(Base):
+    __tablename__ = "saved_listings"
+
+    user_id = Column(Integer, ForeignKey("users.id", ondelete="CASCADE"), nullable=False)
+    listing_id = Column(
+        Integer, ForeignKey("listings.id", ondelete="CASCADE"), nullable=False
+    )
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+
+    __table_args__ = (PrimaryKeyConstraint("user_id", "listing_id"),)

--- a/backend/src/app/repository/saved_listing.py
+++ b/backend/src/app/repository/saved_listing.py
@@ -1,0 +1,80 @@
+from sqlalchemy.orm import Session
+
+from app.models.listing import Listing
+from app.models.saved_listing import SavedListing
+from app.models.user import User
+from app.repository.exceptions import (
+    ResourceConflictError,
+    ResourceNotFoundError,
+)
+
+
+def add(db: Session, user_id: int, listing_id: int) -> SavedListing:
+    """Save a listing for a user. Raises ResourceConflictError if already saved."""
+    user = db.query(User).filter(User.id == user_id).first()
+    if user is None:
+        raise ResourceNotFoundError("User not found")
+
+    listing = db.query(Listing).filter(Listing.id == listing_id).first()
+    if listing is None:
+        raise ResourceNotFoundError("Listing not found")
+
+    existing = (
+        db.query(SavedListing)
+        .filter(
+            SavedListing.user_id == user_id,
+            SavedListing.listing_id == listing_id,
+        )
+        .first()
+    )
+    if existing is not None:
+        raise ResourceConflictError("Listing already saved")
+
+    saved = SavedListing(user_id=user_id, listing_id=listing_id)
+    db.add(saved)
+    db.commit()
+    db.refresh(saved)
+    return saved
+
+
+def remove(db: Session, user_id: int, listing_id: int) -> None:
+    """Remove a saved listing for a user. Raises ResourceNotFoundError if not saved."""
+    saved = (
+        db.query(SavedListing)
+        .filter(
+            SavedListing.user_id == user_id,
+            SavedListing.listing_id == listing_id,
+        )
+        .first()
+    )
+    if saved is None:
+        raise ResourceNotFoundError("Listing not saved")
+
+    db.delete(saved)
+    db.commit()
+
+
+def list_for_user(db: Session, user_id: int, skip: int = 0, limit: int = 100) -> list[Listing]:
+    """Get all listings saved by a user."""
+    return (
+        db.query(Listing)
+        .join(SavedListing, Listing.id == SavedListing.listing_id)
+        .filter(SavedListing.user_id == user_id)
+        .order_by(SavedListing.created_at.desc())
+        .offset(skip)
+        .limit(limit)
+        .all()
+    )
+
+
+def exists(db: Session, user_id: int, listing_id: int) -> bool:
+    """Check if a listing is saved by a user."""
+    return (
+        db.query(SavedListing)
+        .filter(
+            SavedListing.user_id == user_id,
+            SavedListing.listing_id == listing_id,
+        )
+        .first()
+        is not None
+    )

--- a/backend/src/app/routes/saved_listings.py
+++ b/backend/src/app/routes/saved_listings.py
@@ -1,0 +1,75 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+
+from app.core.database import get_db
+from app.core.dependencies import get_current_user
+from app.models.user import User
+from app.repository.exceptions import ResourceConflictError, ResourceNotFoundError
+from app.services.saved_listing import SavedListingService
+
+router = APIRouter(prefix="/saved-listings", tags=["saved-listings"])
+
+
+@router.post("/{listing_id}", status_code=201, response_model=dict)
+async def save_listing(
+    listing_id: int,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Save a listing for the current user."""
+    try:
+        SavedListingService.save(db, current_user.id, listing_id)
+        return {"listing_id": listing_id, "saved": True}
+    except ResourceNotFoundError as e:
+        raise HTTPException(status_code=404, detail=e.detail) from e
+    except ResourceConflictError as e:
+        raise HTTPException(status_code=409, detail=e.detail) from e
+
+
+@router.delete("/{listing_id}", status_code=204, response_model=None)
+async def unsave_listing(
+    listing_id: int,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Remove a saved listing for the current user."""
+    try:
+        SavedListingService.unsave(db, current_user.id, listing_id)
+    except ResourceNotFoundError as e:
+        raise HTTPException(status_code=404, detail=e.detail) from e
+
+
+@router.get("/", response_model=dict)
+async def get_saved_listings(
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Get all saved listings for the current user."""
+    listings = SavedListingService.list_for_user(db, current_user.id)
+
+    results = []
+    for l in listings:
+        results.append(
+            {
+                "id": l.id,
+                "title": l.title,
+                "description": l.description,
+                "price": l.price,
+                "college": l.college_id,
+                "location_text": l.location,
+                "location": l.location,
+                "room_type": l.room_type,
+                "sqft": l.sqft,
+                "start_date": str(l.start_date) if l.start_date else None,
+                "end_date": str(l.end_date) if l.end_date else None,
+                "thumbnail_url": l.thumbnail_url,
+                "image_urls": l.image_urls
+                if l.image_urls is not None
+                else ([l.thumbnail_url] if l.thumbnail_url else []),
+                "latitude": float(l.latitude) if l.latitude is not None else None,
+                "longitude": float(l.longitude) if l.longitude is not None else None,
+                "created_at": str(l.created_at) if l.created_at else None,
+            }
+        )
+
+    return {"count": len(results), "results": results}

--- a/backend/src/app/schemas/saved_listing.py
+++ b/backend/src/app/schemas/saved_listing.py
@@ -1,0 +1,13 @@
+from datetime import datetime
+
+from pydantic import BaseModel
+
+
+class SavedListingResponse(BaseModel):
+    """Schema for saved listing response."""
+
+    user_id: int
+    listing_id: int
+    created_at: datetime
+
+    model_config = {"from_attributes": True}

--- a/backend/src/app/services/saved_listing.py
+++ b/backend/src/app/services/saved_listing.py
@@ -1,0 +1,32 @@
+from sqlalchemy.orm import Session
+
+from app.models.listing import Listing
+from app.models.saved_listing import SavedListing
+from app.repository.saved_listing import (
+    add,
+    exists,
+    list_for_user,
+    remove,
+)
+
+
+class SavedListingService:
+    """Business logic for saved listing operations."""
+
+    @staticmethod
+    def save(db: Session, user_id: int, listing_id: int) -> SavedListing:
+        return add(db, user_id, listing_id)
+
+    @staticmethod
+    def unsave(db: Session, user_id: int, listing_id: int) -> None:
+        return remove(db, user_id, listing_id)
+
+    @staticmethod
+    def list_for_user(
+        db: Session, user_id: int, skip: int = 0, limit: int = 100
+    ) -> list[Listing]:
+        return list_for_user(db, user_id, skip, limit)
+
+    @staticmethod
+    def is_saved(db: Session, user_id: int, listing_id: int) -> bool:
+        return exists(db, user_id, listing_id)

--- a/frontend/src/app/(main)/saved-listings/page.tsx
+++ b/frontend/src/app/(main)/saved-listings/page.tsx
@@ -2,22 +2,51 @@
 
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
-import { MOCK_SAVED_LISTINGS } from "@/lib/listings";
+import { fetchSavedListings } from "@/lib/listings";
+import type { BrowseListing } from "@/lib/listings";
 import { ListingBrowseCard } from "@/components/listings/listing-browse-card";
 import { Card } from "@/components/ui/card";
+import { ACCESS_TOKEN_KEY } from "@/lib/api";
 
 export default function SavedListingsPage() {
   const router = useRouter();
   const [isAuthorized, setIsAuthorized] = useState(false);
+  const [listings, setListings] = useState<BrowseListing[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
 
   useEffect(() => {
-    const token = localStorage.getItem("access_token");
+    const token = localStorage.getItem(ACCESS_TOKEN_KEY);
     if (!token) {
       router.push("/signin");
       return;
     }
     setIsAuthorized(true);
   }, [router]);
+
+  useEffect(() => {
+    if (!isAuthorized) return;
+
+    let cancelled = false;
+    const token = localStorage.getItem(ACCESS_TOKEN_KEY);
+    if (!token) return;
+
+    fetchSavedListings(token)
+      .then((data) => {
+        if (!cancelled) setListings(data);
+      })
+      .catch((e) => {
+        console.error("fetchSavedListings", e);
+        if (!cancelled) setLoadError("Could not load saved listings.");
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [isAuthorized]);
 
   if (!isAuthorized) {
     return (
@@ -33,15 +62,24 @@ export default function SavedListingsPage() {
         <div className="mx-auto max-w-7xl px-4 py-6 md:px-6">
           <h1 className="text-2xl font-semibold tracking-tight md:text-3xl">Saved Listings</h1>
           <p className="mt-1 text-sm text-muted-foreground">
-            {MOCK_SAVED_LISTINGS.length} listing{MOCK_SAVED_LISTINGS.length !== 1 ? "s" : ""} saved
+            {listings.length} listing{listings.length !== 1 ? "s" : ""} saved
           </p>
         </div>
       </div>
 
       <div className="mx-auto max-w-7xl px-4 py-8 md:px-6">
-        {MOCK_SAVED_LISTINGS.length > 0 ? (
+        {loading ? (
+          <Card className="flex flex-col items-center justify-center gap-3 py-16">
+            <p className="text-sm text-muted-foreground">Loading saved listings...</p>
+          </Card>
+        ) : loadError ? (
+          <Card className="flex flex-col items-center justify-center gap-3 py-16">
+            <p className="text-lg font-medium text-foreground">Error loading saved listings</p>
+            <p className="text-sm text-muted-foreground">{loadError}</p>
+          </Card>
+        ) : listings.length > 0 ? (
           <div className="grid auto-rows-max gap-6 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
-            {MOCK_SAVED_LISTINGS.map((listing) => (
+            {listings.map((listing) => (
               <ListingBrowseCard key={listing.id} listing={listing} from="saved-listings" />
             ))}
           </div>

--- a/frontend/src/app/(main)/saved-listings/page.tsx
+++ b/frontend/src/app/(main)/saved-listings/page.tsx
@@ -10,19 +10,18 @@ import { ACCESS_TOKEN_KEY } from "@/lib/api";
 
 export default function SavedListingsPage() {
   const router = useRouter();
-  const [isAuthorized, setIsAuthorized] = useState(false);
+  const [isAuthorized] = useState(() =>
+    typeof window !== "undefined" && !!localStorage.getItem(ACCESS_TOKEN_KEY)
+  );
   const [listings, setListings] = useState<BrowseListing[]>([]);
   const [loading, setLoading] = useState(true);
   const [loadError, setLoadError] = useState<string | null>(null);
 
-  useEffect(() => {
-    const token = localStorage.getItem(ACCESS_TOKEN_KEY);
-    if (!token) {
-      router.push("/signin");
-      return;
-    }
-    setIsAuthorized(true);
-  }, [router]);
+useEffect(() => {
+  if (!isAuthorized) {
+    router.push("/signin");
+  }
+}, [isAuthorized, router]);
 
   useEffect(() => {
     if (!isAuthorized) return;

--- a/frontend/src/lib/listings.ts
+++ b/frontend/src/lib/listings.ts
@@ -1,5 +1,5 @@
 import type { Listing, ListingListApiRow } from "@/types/listing";
-import { API_BASE_URL } from "@/lib/api";
+import { API_BASE_URL, fetchApiJson, postApiJson, deleteApiJson } from "@/lib/api";
 
 /** Listing fields used on browse + cards (mock/API may grow over time). */
 export type BrowseListing = Listing & {
@@ -199,13 +199,6 @@ export const MOCK_BROWSE_LISTINGS: BrowseListing[] = [
 	},
 ];
 
-/** Mock saved listings - subset of browse listings for user's saved collection. */
-export const MOCK_SAVED_LISTINGS: BrowseListing[] = [
-	MOCK_BROWSE_LISTINGS[0], // Modern Studio Near Campus
-	MOCK_BROWSE_LISTINGS[2], // Spacious 1BR in Student Housing
-	MOCK_BROWSE_LISTINGS[4], // Modern Apartment with Kitchen
-];
-
 /** Mock listings owned by the signed-in user. */
 export const MOCK_MY_LISTINGS: BrowseListing[] = [
 	MOCK_BROWSE_LISTINGS[1], // Cozy Dorm Room Available
@@ -377,4 +370,20 @@ export async function fetchBrowseListingById(id: string): Promise<BrowseListing 
 	}
 
 	return fromMock ?? null;
+}
+
+export async function fetchSavedListings(token: string): Promise<BrowseListing[]> {
+	const res = await fetchApiJson<{ count: number; results: ListingListApiRow[] }>(
+		"/api/v1/saved-listings",
+		token,
+	);
+	return res.results.map((row) => toBrowseListing(listingFromListRow(row)));
+}
+
+export async function saveListing(token: string, listingId: number): Promise<void> {
+	await postApiJson(`/api/v1/saved-listings/${listingId}`, token, {});
+}
+
+export async function unsaveListing(token: string, listingId: number): Promise<void> {
+	await deleteApiJson(`/api/v1/saved-listings/${listingId}`, token);
 }


### PR DESCRIPTION
Implements saved listings end-to-end. Replaces MOCK_SAVED_LISTINGS on /saved-listings with real data from the backend.

Backend:
- New SavedListing model (composite PK on user_id + listing_id, cascade delete)
- Repository, service, and routes layers matching existing patterns
- Three endpoints (auth-required):
  - POST /api/v1/saved-listings/{listing_id} — save (201, or 409 if already saved)
  - DELETE /api/v1/saved-listings/{listing_id} — unsave (204, or 404 if not saved)
  - GET /api/v1/saved-listings — list user's saved listings, returns same shape as GET /listings/

Frontend:
- New fetchSavedListings, saveListing, unsaveListing in lib/listings.ts
- /saved-listings page now fetches real data with loading + error states
- Removed MOCK_SAVED_LISTINGS

Note: save/unsave buttons on cards are out of scope. Manual save via POST works for now; UI for saving will be a follow-up PR.

DB note: requires recreating sublease_marketplace.db locally (or running migrations) to pick up the new saved_listings table.

Closes #[issue]