### PR TITLE
fix(navbar): show sign in / sign up buttons when logged out

### DIFF
--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -20,7 +20,7 @@ import {
 import { ModeToggle } from "@/components/mode-toggle";
 import UserButton from "@/components/UserButton";
 import { useRouter } from "next/navigation";
-import { getAccessToken } from "@/lib/auth";
+import { getAccessToken, useIsAuthenticated } from "@/lib/auth";
 import { fetchUnreadMessageCount } from "@/lib/conversations";
 
 const UNREAD_COUNT_POLL_INTERVAL = 30000; // 30 seconds
@@ -102,6 +102,7 @@ function DesktopNavbar() {
   const [query, setQuery] = useState("");
   const [unreadCount, setUnreadCount] = useState(0);
   const pollIntervalRef = useRef<NodeJS.Timeout | null>(null);
+  const isLoggedIn = useIsAuthenticated();
 
   useEffect(() => {
     const loadUnreadCount = async () => {
@@ -156,9 +157,11 @@ function DesktopNavbar() {
           <NavIconLink href="/listings" label="Browse">
             <LayoutGrid className="h-5 w-5" />
           </NavIconLink>
-          <NavIconLinkWithBadge href="/messages" label="Messages" badgeCount={unreadCount}>
-            <MessageCircle className="h-5 w-5" />
-          </NavIconLinkWithBadge>
+          {isLoggedIn && (
+            <NavIconLinkWithBadge href="/messages" label="Messages" badgeCount={unreadCount}>
+              <MessageCircle className="h-5 w-5" />
+            </NavIconLinkWithBadge>
+          )}
           <ModeToggle />
           <UserButton />
         </div>
@@ -173,6 +176,7 @@ function MobileNavbar() {
   const [query, setQuery] = useState("");
   const [unreadCount, setUnreadCount] = useState(0);
   const pollIntervalRef = useRef<NodeJS.Timeout | null>(null);
+  const isLoggedIn = useIsAuthenticated();
 
   useEffect(() => {
     const loadUnreadCount = async () => {
@@ -242,16 +246,18 @@ function MobileNavbar() {
                 >
                   Browse listings
                 </Link>
-                <Link
-                  href="/messages"
-                  className="relative rounded-lg px-2 py-3 text-base font-medium text-foreground active:bg-muted"
-                  onClick={() => setIsOpen(false)}
-                >
-                  Messages
-                  {unreadCount > 0 && (
-                    <span className="absolute right-4 top-1/2 -translate-y-1/2 h-2 w-2 rounded-full bg-red-500" />
-                  )}
-                </Link>
+                {isLoggedIn && (
+                  <Link
+                    href="/messages"
+                    className="relative rounded-lg px-2 py-3 text-base font-medium text-foreground active:bg-muted"
+                    onClick={() => setIsOpen(false)}
+                  >
+                    Messages
+                    {unreadCount > 0 && (
+                      <span className="absolute right-4 top-1/2 -translate-y-1/2 h-2 w-2 rounded-full bg-red-500" />
+                    )}
+                  </Link>
+                )}
               </nav>
             </div>
           </SheetContent>

--- a/frontend/src/components/UserButton.tsx
+++ b/frontend/src/components/UserButton.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -21,55 +22,54 @@ function UserButton() {
     router.push("/");
   }
 
+  if (!isLoggedIn) {
+    return (
+      <div className="flex items-center gap-2">
+        <Button
+          nativeButton={false}
+          variant="ghost"
+          size="sm"
+          render={<Link href="/signin">Sign in</Link>}
+        />
+        <Button
+          nativeButton={false}
+          size="sm"
+          render={<Link href="/signup">Sign up</Link>}
+        />
+      </div>
+    );
+  }
+
   return (
     <DropdownMenu>
       <DropdownMenuTrigger render={<Button variant="ghost" size="icon" />}>
         <User />
       </DropdownMenuTrigger>
       <DropdownMenuContent align="center" className="w-auto min-w-0">
-        {isLoggedIn ? (
-          <>
-            <DropdownMenuItem
-              onClick={() => router.push("/profile")}
-              className="justify-center px-4"
-            >
-              Profile
-            </DropdownMenuItem>
-            <DropdownMenuItem
-              onClick={() => router.push("/my-listings")}
-              className="justify-center px-4"
-            >
-              My Listings
-            </DropdownMenuItem>
-            <DropdownMenuItem
-              onClick={() => router.push("/saved-listings")}
-              className="justify-center px-4"
-            >
-              Saved listings
-            </DropdownMenuItem>
-            <DropdownMenuItem
-              onClick={handleSignOut}
-              className="justify-center px-4"
-            >
-              Sign out
-            </DropdownMenuItem>
-          </>
-        ) : (
-          <>
-            <DropdownMenuItem
-              onClick={() => router.push("/signin")}
-              className="justify-center px-4"
-            >
-              Sign in
-            </DropdownMenuItem>
-            <DropdownMenuItem
-              onClick={() => router.push("/signup")}
-              className="justify-center px-4"
-            >
-              Sign up
-            </DropdownMenuItem>
-          </>
-        )}
+        <DropdownMenuItem
+          onClick={() => router.push("/profile")}
+          className="justify-center px-4"
+        >
+          Profile
+        </DropdownMenuItem>
+        <DropdownMenuItem
+          onClick={() => router.push("/my-listings")}
+          className="justify-center px-4"
+        >
+          My Listings
+        </DropdownMenuItem>
+        <DropdownMenuItem
+          onClick={() => router.push("/saved-listings")}
+          className="justify-center px-4"
+        >
+          Saved listings
+        </DropdownMenuItem>
+        <DropdownMenuItem
+          onClick={handleSignOut}
+          className="justify-center px-4"
+        >
+          Sign out
+        </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>
   );


### PR DESCRIPTION
## Summary
- Renders explicit **Sign in** (ghost) and **Sign up** (primary) buttons in the navbar when there's no session, instead of hiding them inside a profile-icon dropdown that misleads users into thinking they're logged in
- Profile-icon dropdown is preserved for the authenticated state

Closes #230