### PR TITLE
fix(navbar): show text labels next to desktop nav icons

### DIFF
--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -48,13 +48,14 @@ function NavIconLink({
           <Link
             href={href}
             aria-label={label}
-            className={buttonVariants({ variant: "ghost", size: "icon" })}
+            className={buttonVariants({ variant: "ghost" })}
           >
             {children}
+            <span className="hidden lg:inline">{label}</span>
           </Link>
         }
       />
-      <TooltipContent>{label}</TooltipContent>
+      <TooltipContent className="lg:hidden">{label}</TooltipContent>
     </Tooltip>
   );
 }


### PR DESCRIPTION
## Summary
- At `lg+` each nav item renders **icon + text** (Browse, Map, Messages) instead of just an icon
- Below `lg` the icon-only state stays, with the tooltip preserved so destinations are still discoverable on smaller desktop widths
- Mobile drawer already shows full labels — untouched

Closes #232