### PR TITLE
feat(my-listings): add Create a listing CTA on empty state

### DIFF
--- a/frontend/src/app/(main)/my-listings/page.tsx
+++ b/frontend/src/app/(main)/my-listings/page.tsx
@@ -1,9 +1,10 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
+import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
-import { Loader2, Pencil, Trash2 } from "lucide-react";
+import { Loader2, Pencil, Plus, Trash2 } from "lucide-react";
 import { Card } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import {
@@ -176,11 +177,20 @@ export default function MyListingsPage() {
 						))}
 					</div>
 				) : (
-					<Card className="flex flex-col items-center justify-center gap-3 py-16">
+					<Card className="flex flex-col items-center justify-center gap-4 py-16">
 						<p className="text-lg font-medium text-foreground">No listings yet</p>
 						<p className="text-sm text-muted-foreground">
 							You haven&apos;t posted any subleases yet.
 						</p>
+						<Button
+							nativeButton={false}
+							render={
+								<Link href="/list">
+									<Plus className="size-4" aria-hidden />
+									Create a listing
+								</Link>
+							}
+						/>
 					</Card>
 				)}
 			</div>


### PR DESCRIPTION
## Summary
- Adds a primary **Create a listing** button to the empty state on `/my-listings` so users with no listings have a clear next action instead of a dead-end card
- Button links to `/list` with a `+` icon

Closes #245