### PR TITLE
feat(uploads): restrict image uploads to PNG and JPEG only

### DIFF
--- a/backend/src/app/routes/profile.py
+++ b/backend/src/app/routes/profile.py
@@ -88,22 +88,20 @@ ICON_DIR = Path("media") / "icons"
 ALLOWED_ICON_TYPES: dict[str, str] = {
     "image/jpeg": ".jpg",
     "image/png": ".png",
-    "image/webp": ".webp",
-    "image/gif": ".gif",
 }
 MAX_ICON_BYTES = 5 * 1024 * 1024
 
 
 def _sniff_image_mime(data: bytes) -> str | None:
-    """Return the MIME type implied by the first few bytes, or None."""
+    """Return the MIME type implied by the first few bytes, or None.
+
+    Restricted to PNG and JPEG — other formats (gif, webp, svg, etc.)
+    are rejected even if the client sets a matching Content-Type header.
+    """
     if data.startswith(b"\xff\xd8\xff"):
         return "image/jpeg"
     if data.startswith(b"\x89PNG\r\n\x1a\n"):
         return "image/png"
-    if data[:6] in (b"GIF87a", b"GIF89a"):
-        return "image/gif"
-    if data[:4] == b"RIFF" and data[8:12] == b"WEBP":
-        return "image/webp"
     return None
 
 
@@ -118,7 +116,7 @@ async def upload_my_icon(
     if extension is None:
         raise HTTPException(
             status_code=415,
-            detail="Unsupported image type. Use jpg, png, webp, or gif.",
+            detail="Unsupported image type. Only PNG and JPEG are allowed.",
         )
     contents = await file.read()
     if len(contents) > MAX_ICON_BYTES:

--- a/backend/src/app/schemas/listing.py
+++ b/backend/src/app/schemas/listing.py
@@ -4,10 +4,10 @@ from datetime import datetime
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 # Accepts: https URLs, /media/ relative paths, or base64-encoded data URIs
-# whose MIME is one of the four bitmap formats we support. Rejects
-# javascript:, file:, data:image/svg+xml, and unscoped data: URIs.
+# whose MIME is PNG or JPEG. Rejects everything else — javascript:, file:,
+# data:image/svg+xml, data:image/gif, data:image/webp, unscoped data: URIs.
 _IMAGE_URL_RE = re.compile(
-    r"^(?:https?://|/media/|data:image/(?:jpeg|jpg|png|gif|webp);base64,)",
+    r"^(?:https?://|/media/|data:image/(?:jpeg|jpg|png);base64,)",
     re.IGNORECASE,
 )
 
@@ -22,7 +22,7 @@ def _validate_image_urls(values: list[str]) -> list[str]:
         if not _IMAGE_URL_RE.match(s):
             raise ValueError(
                 "image_urls must be https URLs, /media/ paths, or "
-                "data:image/(jpeg|png|gif|webp);base64 URIs"
+                "data:image/(jpeg|png);base64 URIs"
             )
     return values
 

--- a/frontend/src/components/listing-form.tsx
+++ b/frontend/src/components/listing-form.tsx
@@ -173,10 +173,16 @@ export function ListingForm({
 
 	const addImageFiles = useCallback(
 		async (files: FileList | File[]) => {
-			const list = Array.from(files).filter((f) => f.type.startsWith("image/"));
+			const all = Array.from(files);
+			const list = all.filter(
+				(f) => f.type === "image/png" || f.type === "image/jpeg",
+			);
 			if (list.length === 0) {
-				toast.error("Please choose image files");
+				toast.error("Photos must be PNG or JPEG images");
 				return;
+			}
+			if (list.length < all.length) {
+				toast.warning("Some files were skipped — only PNG and JPEG are allowed");
 			}
 			const current = form.getValues("photos").length;
 			let added = 0;
@@ -498,14 +504,14 @@ export function ListingForm({
 								<FieldLabel htmlFor="form-listing-photos-trigger">Photos</FieldLabel>
 								<p className="mb-3 text-sm text-muted-foreground" id="form-listing-photos-hint">
 									Drag and drop images here or click to browse. First photo is the cover (up to{" "}
-									{MAX_PHOTOS} images, 1.5 MB each).
+									{MAX_PHOTOS} PNG or JPEG images, 1.5 MB each).
 								</p>
 
 								<input
 									ref={fileInputRef}
 									id="form-listing-photos-input"
 									type="file"
-									accept="image/*"
+									accept="image/png,image/jpeg"
 									multiple
 									className="sr-only"
 									tabIndex={-1}

--- a/frontend/src/components/signup-form.tsx
+++ b/frontend/src/components/signup-form.tsx
@@ -126,8 +126,8 @@ export function SignupForm({
 
   function handleIconChange(event: React.ChangeEvent<HTMLInputElement>) {
     const file = event.target.files?.[0] ?? null;
-    if (file && !file.type.startsWith("image/")) {
-      toast.error("Please select an image file.");
+    if (file && file.type !== "image/png" && file.type !== "image/jpeg") {
+      toast.error("Profile photo must be a PNG or JPEG image.");
       event.target.value = "";
       return;
     }
@@ -245,7 +245,7 @@ export function SignupForm({
                   <input
                     ref={fileInputRef}
                     type="file"
-                    accept="image/*"
+                    accept="image/png,image/jpeg"
                     onChange={handleIconChange}
                     className="hidden"
                   />


### PR DESCRIPTION
## Summary
Tightens the image upload allow-list across the stack so anything other than PNG or JPEG is rejected at every layer (file picker, frontend filter, backend MIME check, and magic-byte sniff).

**Backend**
- `routes/profile.py`: drop `webp` + `gif` from `ALLOWED_ICON_TYPES` and from the magic-byte sniffer; clearer 415 message
- `schemas/listing.py`: data-URL regex now only matches `data:image/(jpeg|jpg|png);base64,` — `gif`, `webp`, `svg`, etc. are rejected

**Frontend**
- `signup-form.tsx`: `accept="image/png,image/jpeg"` on the avatar input + tightened JS check
- `listing-form.tsx`: same on the photo input, filter file drops/selects to PNG/JPEG only, warn on skipped files, updated helper text

Closes #238