### PR TITLE
Issue #265

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,32 @@
+# Backend environment variables.
+# Copy to `backend/.env` and fill in the secrets. `.env` is gitignored.
+
+# --- Core ---
+# Deployment environment: "development" or "production".
+ENVIRONMENT=development
+
+# JWT signing key. Must be at least 32 bytes in production.
+# Generate with: python -c "import secrets; print(secrets.token_urlsafe(48))"
+SECRET_KEY=change_me_to_a_secure_32_byte_secret_key
+
+# Database connection URL. Defaults to a local SQLite file.
+DATABASE_URL=sqlite:///./sublease_marketplace.db
+
+# Comma-separated list of origins permitted by CORS.
+# Example for prod: CORS_ORIGINS=["https://sublease.example.com"]
+CORS_ORIGINS=["http://localhost:3000"]
+
+# --- Email (Resend) ---
+# API key from https://resend.com/api-keys. Leave blank locally to skip
+# real email sends; the auth flow will still succeed and log a warning.
+RESEND_API_KEY=
+
+# From address for outbound email. The default `onboarding@resend.dev`
+# is Resend's sandbox sender and ONLY delivers to the address registered
+# on your Resend account — fine for local testing. Replace with a
+# verified-domain sender for production.
+RESEND_FROM_EMAIL=onboarding@resend.dev
+
+# Public URL of the frontend, used to build links in outbound emails
+# (e.g. the password reset link). No trailing slash.
+FRONTEND_BASE_URL=http://localhost:3000

--- a/backend/README.md
+++ b/backend/README.md
@@ -202,9 +202,9 @@ The full OpenAPI specification is available in [`backend/sublease-gang.yaml`](ba
 | POST   | `/api/v1/auth/signup`                 | Create a new account             |
 | POST   | `/api/v1/auth/login`                  | Log in                           |
 | POST   | `/api/v1/auth/logout`                 | Log out (authenticated)          |
-| POST   | `/api/v1/auth/refresh`                | Refresh tokens (stub)            |
-| POST   | `/api/v1/auth/forgot_password`        | Request password reset (stub)    |
-| PUT    | `/api/v1/auth/reset_password`         | Reset password (stub)            |
+| POST   | `/api/v1/auth/refresh`                | Refresh tokens                   |
+| POST   | `/api/v1/auth/forgot_password`        | Request password reset email     |
+| PUT    | `/api/v1/auth/reset_password`         | Reset password using token       |
 | POST   | `/api/v1/users/`                      | Create a new user                |
 | GET    | `/api/v1/users/me`                    | Get current user profile         |
 | PATCH  | `/api/v1/users/me`                    | Update current user profile      |

--- a/backend/README.md
+++ b/backend/README.md
@@ -86,7 +86,7 @@ cd backend
 uv sync --group dev
 ```
 
-Create a `.env` file in the `backend/` directory (optional — defaults are provided):
+Create a `.env` file in the `backend/` directory. Copy `backend/.env.example` for a fully-documented template — defaults are provided so the file is optional, but you'll need real values for any feature that talks to a third-party service.
 
 ```env
 SECRET_KEY=change_me_to_a_secure_32_byte_secret_key
@@ -94,6 +94,22 @@ DATABASE_URL=sqlite:///./sublease_marketplace.db
 ACCESS_TOKEN_EXPIRE_MINUTES=30
 ENVIRONMENT=development
 ```
+
+#### Email (Resend)
+
+Password reset emails are sent through [Resend](https://resend.com). To test the flow locally:
+
+1. Get an API key from <https://resend.com/api-keys>.
+2. Add it to `backend/.env`:
+
+   ```env
+   RESEND_API_KEY=re_your_key_here
+   FRONTEND_BASE_URL=http://localhost:3000
+   ```
+
+3. The default sender (`onboarding@resend.dev`) is Resend's sandbox — it only delivers to the email address registered on your Resend account, which is fine for dev. For production, verify a domain in Resend and set `RESEND_FROM_EMAIL` to an address on that domain.
+
+If `RESEND_API_KEY` is empty, the auth flow still works — sends are skipped and a warning is logged, so CI and local-only setups don't need a key.
 
 ### Frontend
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "python-multipart>=0.0.22",
     "requests>=2.32.5",
     "pydantic-settings>=2.13.0",
+    "resend>=2.4.0",
     "sqlalchemy>=2.0.46",
 ]
 

--- a/backend/src/app/core/settings.py
+++ b/backend/src/app/core/settings.py
@@ -96,23 +96,23 @@ class Settings(BaseSettings):
     )
 
     @model_validator(mode="after")
-    def _enforce_secret_key_in_production(self) -> "Settings":
+    def _enforce_secret_key_in_production(self) -> Settings:
         if self.environment != "production":
             return self
         if self.secret_key == _DEFAULT_SECRET_KEY:
             raise ValueError(
                 "SECRET_KEY is set to the default placeholder. "
-                "Set a unique SECRET_KEY in the production environment."
+                "Set a unique SECRET_KEY in the production environment.",
             )
         if len(self.secret_key.encode("utf-8")) < _MIN_SECRET_KEY_BYTES:
             raise ValueError(
                 f"SECRET_KEY must be at least {_MIN_SECRET_KEY_BYTES} bytes "
-                "in production."
+                "in production.",
             )
         return self
 
     @model_validator(mode="after")
-    def _enforce_safe_cors_in_production(self) -> "Settings":
+    def _enforce_safe_cors_in_production(self) -> Settings:
         if self.environment != "production":
             return self
         for origin in self.cors_origins:
@@ -121,17 +121,17 @@ class Settings(BaseSettings):
                 raise ValueError("CORS origins must not be blank in production.")
             if "*" in normalized:
                 raise ValueError(
-                    "Wildcard CORS origins are not allowed in production."
+                    "Wildcard CORS origins are not allowed in production.",
                 )
             if normalized.startswith("http://"):
                 raise ValueError(
                     "Plaintext http:// CORS origins are not allowed in "
-                    "production. Use https://."
+                    "production. Use https://.",
                 )
             if "localhost" in normalized or "127.0.0.1" in normalized:
                 raise ValueError(
                     "localhost/127.0.0.1 CORS origins are not allowed in "
-                    "production."
+                    "production.",
                 )
         return self
 

--- a/backend/src/app/core/settings.py
+++ b/backend/src/app/core/settings.py
@@ -68,6 +68,33 @@ class Settings(BaseSettings):
         ),
     )
 
+    resend_api_key: str = Field(
+        default="",
+        description=(
+            "API key for Resend transactional email. When empty, email sends "
+            "are skipped and logged; auth flows still succeed so local dev "
+            "without a key keeps working."
+        ),
+    )
+
+    resend_from_email: str = Field(
+        default="onboarding@resend.dev",
+        description=(
+            "From address for outbound email. The default is Resend's "
+            "sandbox sender, which only delivers to the address registered "
+            "to your Resend account. Replace with a verified-domain address "
+            "before relying on it in production."
+        ),
+    )
+
+    frontend_base_url: str = Field(
+        default="http://localhost:3000",
+        description=(
+            "Public base URL of the frontend (no trailing slash). Used to "
+            "build links embedded in outbound emails (e.g. password reset)."
+        ),
+    )
+
     @model_validator(mode="after")
     def _enforce_secret_key_in_production(self) -> "Settings":
         if self.environment != "production":

--- a/backend/src/app/routes/auth.py
+++ b/backend/src/app/routes/auth.py
@@ -96,7 +96,6 @@ async def logout(
                     revoked_specific = True
     if not revoked_specific:
         TokenService.revoke_all_refresh_for_user(db, current_user.id)
-    return
 
 
 @router.post("/refresh", response_model=TokenResponse)

--- a/backend/src/app/routes/auth.py
+++ b/backend/src/app/routes/auth.py
@@ -25,6 +25,7 @@ from app.schemas.auth import (
     SignupRequest,
     TokenResponse,
 )
+from app.services.email import send_password_reset_email
 from app.services.token import TokenService
 from app.services.user import UserService
 
@@ -187,6 +188,8 @@ async def forgot_password(
         verify_password(payload.email, DUMMY_PASSWORD_HASH)
         return response
     reset_token = TokenService.issue_reset_token(db, user.id)
+    reset_url = f"{settings.frontend_base_url}/reset-password?token={reset_token}"
+    send_password_reset_email(user.email, reset_url)
     if settings.environment == "development":
         logger.info("Password reset token for user %s: %s", user.id, reset_token)
         response["reset_token"] = reset_token

--- a/backend/src/app/routes/auth.py
+++ b/backend/src/app/routes/auth.py
@@ -187,7 +187,10 @@ async def forgot_password(
         verify_password(payload.email, DUMMY_PASSWORD_HASH)
         return response
     reset_token = TokenService.issue_reset_token(db, user.id)
-    reset_url = f"{settings.frontend_base_url}/reset-password?token={reset_token}"
+    # rstrip in case FRONTEND_BASE_URL is misconfigured with a trailing slash —
+    # the docs say "no trailing slash" but defending here keeps the path clean.
+    base = settings.frontend_base_url.rstrip("/")
+    reset_url = f"{base}/reset-password?token={reset_token}"
     send_password_reset_email(user.email, reset_url)
     if settings.environment == "development":
         logger.info("Password reset token for user %s: %s", user.id, reset_token)

--- a/backend/src/app/services/email.py
+++ b/backend/src/app/services/email.py
@@ -32,7 +32,7 @@ def send_password_reset_email(to_email: str, reset_url: str) -> bool:
     params: resend.Emails.SendParams = {
         "from": settings.resend_from_email,
         "to": [to_email],
-        "subject": "Reset your Sublease Gang password",
+        "subject": "Reset your SubLease password",
         "html": (
             "<p>We received a request to reset your password.</p>"
             f'<p><a href="{safe_url}">Reset your password</a></p>'

--- a/backend/src/app/services/email.py
+++ b/backend/src/app/services/email.py
@@ -1,0 +1,56 @@
+import logging
+from html import escape
+
+import resend
+from resend.exceptions import ResendError
+
+from app.core.settings import settings
+
+logger = logging.getLogger(__name__)
+
+
+def _is_configured() -> bool:
+    return bool(settings.resend_api_key)
+
+
+def send_password_reset_email(to_email: str, reset_url: str) -> bool:
+    """Send a password-reset email via Resend.
+
+    Returns True on a successful send, False otherwise. Failures are logged
+    but never raised — the caller (forgot_password) must always return 200
+    to avoid leaking whether an email is registered.
+    """
+    if not _is_configured():
+        logger.warning(
+            "RESEND_API_KEY is not set; skipping password reset email to %s",
+            to_email,
+        )
+        return False
+
+    resend.api_key = settings.resend_api_key
+    safe_url = escape(reset_url, quote=True)
+    params: resend.Emails.SendParams = {
+        "from": settings.resend_from_email,
+        "to": [to_email],
+        "subject": "Reset your Sublease Gang password",
+        "html": (
+            "<p>We received a request to reset your password.</p>"
+            f'<p><a href="{safe_url}">Reset your password</a></p>'
+            "<p>This link expires in "
+            f"{settings.reset_token_expire_minutes} minutes. If you did not "
+            "request a reset, you can safely ignore this email.</p>"
+        ),
+        "text": (
+            "We received a request to reset your password.\n\n"
+            f"Reset your password: {reset_url}\n\n"
+            f"This link expires in {settings.reset_token_expire_minutes} "
+            "minutes. If you did not request a reset, you can safely ignore "
+            "this email."
+        ),
+    }
+    try:
+        resend.Emails.send(params)
+    except ResendError:
+        logger.exception("Failed to send password reset email to %s", to_email)
+        return False
+    return True

--- a/backend/src/app/services/email.py
+++ b/backend/src/app/services/email.py
@@ -1,24 +1,45 @@
 import logging
+import threading
 from html import escape
 
 import resend
-from resend.exceptions import ResendError
+from resend.exceptions import ResendError  # noqa: F401  re-exported for tests
 
 from app.core.settings import settings
 
 logger = logging.getLogger(__name__)
+
+# The Resend SDK reads `resend.api_key` as module-level state inside its
+# request layer, so we set it once under a lock instead of mutating it on
+# every send. Without this, two concurrent FastAPI workers could interleave
+# their assignments and a request could see another's key — a classic
+# global-state footgun.
+_api_key_lock = threading.Lock()
+_api_key_set = False
 
 
 def _is_configured() -> bool:
     return bool(settings.resend_api_key)
 
 
+def _ensure_api_key_configured() -> None:
+    global _api_key_set
+    if _api_key_set and resend.api_key == settings.resend_api_key:
+        return
+    with _api_key_lock:
+        if _api_key_set and resend.api_key == settings.resend_api_key:
+            return
+        resend.api_key = settings.resend_api_key
+        _api_key_set = True
+
+
 def send_password_reset_email(to_email: str, reset_url: str) -> bool:
     """Send a password-reset email via Resend.
 
-    Returns True on a successful send, False otherwise. Failures are logged
-    but never raised — the caller (forgot_password) must always return 200
-    to avoid leaking whether an email is registered.
+    Returns True on a successful send, False otherwise. Any exception from
+    the SDK (ResendError, network/transport errors, etc.) is caught, logged,
+    and turned into False — the caller (forgot_password) must always return
+    200 to avoid leaking whether an email is registered.
     """
     if not _is_configured():
         logger.warning(
@@ -27,7 +48,7 @@ def send_password_reset_email(to_email: str, reset_url: str) -> bool:
         )
         return False
 
-    resend.api_key = settings.resend_api_key
+    _ensure_api_key_configured()
     safe_url = escape(reset_url, quote=True)
     params: resend.Emails.SendParams = {
         "from": settings.resend_from_email,
@@ -50,7 +71,7 @@ def send_password_reset_email(to_email: str, reset_url: str) -> bool:
     }
     try:
         resend.Emails.send(params)
-    except ResendError:
+    except Exception:
         logger.exception("Failed to send password reset email to %s", to_email)
         return False
     return True

--- a/backend/sublease-gang.yaml
+++ b/backend/sublease-gang.yaml
@@ -376,7 +376,13 @@ paths:
 
   /auth/forgot_password:
     post:
-      summary: Send email to reset password
+      summary: Request a password-reset email
+      description: |
+        Always returns 200 regardless of whether the email is registered, to
+        prevent account enumeration. When a matching account exists, a reset
+        link is dispatched via email; email-provider failures are logged but
+        not surfaced to the caller. In development the issued reset token is
+        included in the response body for local testing.
       requestBody:
         required: true
         content:
@@ -388,32 +394,37 @@ paths:
               properties:
                 email:
                   type: string
+                  format: email
                   example: "example@mail.com"
       responses:
         "200":
-          description: Successfully sent password reset email
+          description: Request accepted (sent if the email is registered)
           content:
             application/json:
               schema:
                 type: object
+                required: [message]
                 properties:
-                  success:
-                    type: boolean
-                    example: true
-        "400":
-          description: Failed to send password reset email
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  error:
+                  message:
                     type: string
-                    example: "Invalid"
+                    example: "If that email is registered, a reset link has been sent."
+                  reset_token:
+                    type: string
+                    description: Present only when ENVIRONMENT=development, for local testing.
+        "400":
+          description: Invalid input (e.g. malformed email)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
 
   /auth/reset_password:
     put:
-      summary: Change current password to new password
+      summary: Reset password using a token from forgot_password
+      description: |
+        Consumes a single-use reset token issued by /auth/forgot_password and
+        sets a new password. After a successful reset, all of the user's
+        active reset tokens and refresh tokens are revoked.
       requestBody:
         required: true
         content:
@@ -421,32 +432,35 @@ paths:
             schema:
               type: object
               required:
+                - token
                 - new_password
               properties:
+                token:
+                  type: string
+                  description: Reset token issued by /auth/forgot_password.
                 new_password:
                   type: string
-                  example: "secret-password"
+                  minLength: 12
+                  maxLength: 128
+                  example: "correct-horse-battery-staple"
       responses:
         "200":
-          description: Successfully changed password
+          description: Password reset
           content:
             application/json:
               schema:
                 type: object
+                required: [message]
                 properties:
-                  success:
-                    type: boolean
-                    example: true
-        "400":
-          description: Failed to change password
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  error:
+                  message:
                     type: string
-                    example: "Invalid input"
+                    example: "Password has been reset successfully."
+        "400":
+          description: Invalid input or invalid/expired reset token
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
   /users:
     post:
       summary: Create a new user account (register)

--- a/backend/tests/integration/test_routes_auth.py
+++ b/backend/tests/integration/test_routes_auth.py
@@ -104,7 +104,7 @@ class TestLogout:
         # Sign up once for one session, then log in again to mint a second
         # refresh token (simulating two devices).
         first = self._signup_and_get_tokens(
-            client, email="logout1@example.com", username="logout1"
+            client, email="logout1@example.com", username="logout1",
         )
         client.post(
             "/api/v1/auth/login",
@@ -132,7 +132,7 @@ class TestLogout:
         from app.models.token import Token
 
         first = self._signup_and_get_tokens(
-            client, email="logout2@example.com", username="logout2"
+            client, email="logout2@example.com", username="logout2",
         )
         client.post(
             "/api/v1/auth/login",
@@ -153,15 +153,15 @@ class TestLogout:
         assert active == 0
 
     def test_logout_with_other_users_refresh_token_falls_back_to_revoke_all(
-        self, client, db_session
+        self, client, db_session,
     ):
         from app.models.token import Token
 
         attacker = self._signup_and_get_tokens(
-            client, email="atk@example.com", username="atkuser"
+            client, email="atk@example.com", username="atkuser",
         )
         victim = self._signup_and_get_tokens(
-            client, email="vic@example.com", username="vicuser"
+            client, email="vic@example.com", username="vicuser",
         )
 
         # Attacker tries to log out using the victim's refresh token. Should
@@ -241,7 +241,7 @@ class TestRefresh:
         assert resp.json()["detail"] == "User not found or account disabled"
 
     def test_refresh_token_issued_before_password_change_rejected(
-        self, client, db_session
+        self, client, db_session,
     ):
         from datetime import UTC, datetime, timedelta
 
@@ -300,8 +300,9 @@ class TestRefresh:
         assert followup.status_code == 401
 
     def test_refresh_token_without_jti_rejected(self, client, db_session):
-        import jwt
         from datetime import UTC, datetime, timedelta
+
+        import jwt
 
         from app.core.auth import ALGORITHM, SECRET_KEY
 
@@ -325,8 +326,9 @@ class TestRefresh:
         assert resp.status_code == 401
 
     def test_refresh_token_with_unknown_jti_rejected(self, client, db_session):
-        import jwt
         from datetime import UTC, datetime, timedelta
+
+        import jwt
 
         from app.core.auth import ALGORITHM, SECRET_KEY
 
@@ -395,7 +397,7 @@ class TestForgotPassword:
         assert calls[0][1] == auth_routes.DUMMY_PASSWORD_HASH
 
     def test_production_mode_omits_token_from_response_and_logs(
-        self, client, monkeypatch, caplog
+        self, client, monkeypatch, caplog,
     ):
         from app.routes import auth as auth_routes
 
@@ -415,6 +417,72 @@ class TestForgotPassword:
         # No log record should contain a JWT (three dot-separated base64 segments).
         for record in caplog.records:
             assert record.getMessage().count(".") < 2 or "eyJ" not in record.getMessage()
+
+    def test_registered_email_triggers_send(self, client, monkeypatch):
+        """A known email triggers exactly one email send with the reset URL."""
+        from app.routes import auth as auth_routes
+
+        calls: list[tuple[str, str]] = []
+
+        def spy_send(to_email: str, reset_url: str) -> bool:
+            calls.append((to_email, reset_url))
+            return True
+
+        monkeypatch.setattr(auth_routes, "send_password_reset_email", spy_send)
+        monkeypatch.setattr(
+            auth_routes.settings, "frontend_base_url", "http://localhost:3000",
+        )
+        client.post(
+            "/api/v1/auth/signup",
+            json=_signup_payload(email="send@example.com", username="senduser"),
+        )
+        resp = client.post(
+            "/api/v1/auth/forgot_password",
+            json={"email": "send@example.com"},
+        )
+        assert resp.status_code == 200
+        assert len(calls) == 1
+        to_email, reset_url = calls[0]
+        assert to_email == "send@example.com"
+        assert reset_url.startswith("http://localhost:3000/reset-password?token=")
+        # The token in the URL must match the one returned for dev convenience.
+        assert reset_url.endswith(resp.json()["reset_token"])
+
+    def test_unknown_email_does_not_send(self, client, monkeypatch):
+        """An unknown email must not trigger a send (no enumeration via mail logs)."""
+        from app.routes import auth as auth_routes
+
+        calls: list[tuple[str, str]] = []
+
+        def spy_send(to_email: str, reset_url: str) -> bool:
+            calls.append((to_email, reset_url))
+            return True
+
+        monkeypatch.setattr(auth_routes, "send_password_reset_email", spy_send)
+        resp = client.post(
+            "/api/v1/auth/forgot_password",
+            json={"email": "nobody@example.com"},
+        )
+        assert resp.status_code == 200
+        assert calls == []
+
+    def test_send_failure_does_not_break_response(self, client, monkeypatch):
+        """Even if the email provider fails, the endpoint still returns 200."""
+        from app.routes import auth as auth_routes
+
+        def failing_send(to_email: str, reset_url: str) -> bool:
+            return False
+
+        monkeypatch.setattr(auth_routes, "send_password_reset_email", failing_send)
+        client.post(
+            "/api/v1/auth/signup",
+            json=_signup_payload(email="fail@example.com", username="failuser"),
+        )
+        resp = client.post(
+            "/api/v1/auth/forgot_password",
+            json={"email": "fail@example.com"},
+        )
+        assert resp.status_code == 200
 
 
 class TestResetPassword:
@@ -497,8 +565,9 @@ class TestResetPassword:
         assert leftover.status_code == 400
 
     def test_reset_token_without_jti_rejected(self, client, db_session):
-        import jwt
         from datetime import UTC, datetime, timedelta
+
+        import jwt
 
         from app.core.auth import ALGORITHM, SECRET_KEY
 

--- a/backend/tests/unit/test_email_service.py
+++ b/backend/tests/unit/test_email_service.py
@@ -1,0 +1,72 @@
+from app.services import email as email_service
+
+
+def test_skips_send_when_api_key_missing(monkeypatch, caplog):
+    """No key configured ⇒ skip send, log warning, return False, don't raise."""
+    monkeypatch.setattr(email_service.settings, "resend_api_key", "")
+
+    sent: list[dict] = []
+
+    def fake_send(params):
+        sent.append(params)
+        return {"id": "should-not-happen"}
+
+    monkeypatch.setattr(email_service.resend.Emails, "send", fake_send)
+    with caplog.at_level("WARNING", logger="app.services.email"):
+        result = email_service.send_password_reset_email(
+            "user@example.com", "http://localhost:3000/reset-password?token=abc",
+        )
+    assert result is False
+    assert sent == []
+    assert any("RESEND_API_KEY" in r.getMessage() for r in caplog.records)
+
+
+def test_sends_with_correct_params_when_configured(monkeypatch):
+    """A configured key ⇒ resend.Emails.send is called with from/to/subject."""
+    monkeypatch.setattr(email_service.settings, "resend_api_key", "re_test_key")
+    monkeypatch.setattr(
+        email_service.settings, "resend_from_email", "noreply@example.com",
+    )
+
+    captured: dict = {}
+
+    def fake_send(params):
+        captured.update(params)
+        return {"id": "fake-message-id"}
+
+    monkeypatch.setattr(email_service.resend.Emails, "send", fake_send)
+    reset_url = "http://localhost:3000/reset-password?token=jwt.token.value"
+    result = email_service.send_password_reset_email(
+        "user@example.com", reset_url,
+    )
+    assert result is True
+    assert captured["from"] == "noreply@example.com"
+    assert captured["to"] == ["user@example.com"]
+    assert reset_url in captured["text"]
+    # The HTML body must escape the URL inside the href attribute.
+    # (We pass a benign URL here, so it remains unchanged after escape().)
+    assert reset_url in captured["html"]
+
+
+def test_returns_false_when_resend_raises(monkeypatch, caplog):
+    """A Resend SDK error must be caught and turned into False — never raised."""
+    monkeypatch.setattr(email_service.settings, "resend_api_key", "re_test_key")
+
+    def boom(_params):
+        raise email_service.ResendError(
+            code=500,
+            error_type="api_error",
+            message="boom",
+            suggested_action="retry",
+        )
+
+    monkeypatch.setattr(email_service.resend.Emails, "send", boom)
+    with caplog.at_level("ERROR", logger="app.services.email"):
+        result = email_service.send_password_reset_email(
+            "user@example.com", "http://localhost:3000/reset-password?token=x",
+        )
+    assert result is False
+    assert any(
+        "Failed to send password reset email" in r.getMessage()
+        for r in caplog.records
+    )

--- a/backend/tests/unit/test_user_service.py
+++ b/backend/tests/unit/test_user_service.py
@@ -52,7 +52,7 @@ class TestUserServiceAuthenticate:
         with (
             patch("app.services.user.get_user_by_email", return_value=None),
             patch(
-                "app.services.user.verify_password", return_value=False
+                "app.services.user.verify_password", return_value=False,
             ) as verify,
             pytest.raises(ResourceNotFoundError),
         ):

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -87,6 +87,7 @@ dependencies = [
     { name = "pyjwt" },
     { name = "python-multipart" },
     { name = "requests" },
+    { name = "resend" },
     { name = "sqlalchemy" },
 ]
 
@@ -107,6 +108,7 @@ requires-dist = [
     { name = "pyjwt", specifier = ">=2.11.0" },
     { name = "python-multipart", specifier = ">=0.0.22" },
     { name = "requests", specifier = ">=2.32.5" },
+    { name = "resend", specifier = ">=2.4.0" },
     { name = "sqlalchemy", specifier = ">=2.0.46" },
 ]
 
@@ -720,6 +722,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf", size = 134517, upload-time = "2025-08-18T20:46:02.573Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6", size = 64738, upload-time = "2025-08-18T20:46:00.542Z" },
+]
+
+[[package]]
+name = "resend"
+version = "2.30.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "requests" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d5/b5/dffc1acd852c708c48626d064a54c83acf0f6c8f097efc14e3b5c3a3ad99/resend-2.30.0.tar.gz", hash = "sha256:4c3c634316ad1a1fe7c5453afdd560c7d318ba18960149a8159f3bed334eb386", size = 43201, upload-time = "2026-05-04T16:23:43.203Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/92/05/c1114a7d29e0543d815cb9b5ac0f00b6ea7bb65507d952f2896d61acdc2b/resend-2.30.0-py2.py3-none-any.whl", hash = "sha256:a8993ad6be911b039f86d5853bb2b478cc2aa66c82f1829f0b1b2e0753cf09c4", size = 68388, upload-time = "2026-05-04T16:23:42.172Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
  - Wires Resend into `POST /api/v1/auth/forgot_password` so users actually receive a reset link instead of just having a token logged.                                  
  - Adds `RESEND_API_KEY`, `RESEND_FROM_EMAIL`, `FRONTEND_BASE_URL` settings with safe defaults (empty key → skip + warn, so CI / local-without-key still passes).         
  - New `backend/.env.example` documents every backend env var in one place.             
  - New `backend/src/app/services/email.py` wraps the Resend SDK; never raises into the route, so a provider outage can't break auth.                                          
  - 6 new tests (3 integration, 3 unit) cover the wiring and the email service.