### PR TITLE
Add Playwright e2e setup with signup smoke test

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -13,6 +13,11 @@
 # testing
 /coverage
 
+# playwright
+test-results/
+playwright-report/
+playwright/.cache/
+
 # next.js
 /.next/
 /out/

--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -28,6 +28,7 @@
         "zod": "^4.3.6",
       },
       "devDependencies": {
+        "@playwright/test": "^1.48.0",
         "@tailwindcss/postcss": "^4.2.4",
         "@types/node": "^25.6.0",
         "@types/react": "^19.2.14",
@@ -293,6 +294,8 @@
     "@open-draft/logger": ["@open-draft/logger@0.3.0", "", { "dependencies": { "is-node-process": "^1.2.0", "outvariant": "^1.4.0" } }, "sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ=="],
 
     "@open-draft/until": ["@open-draft/until@2.1.0", "", {}, "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg=="],
+
+    "@playwright/test": ["@playwright/test@1.59.1", "", { "dependencies": { "playwright": "1.59.1" }, "bin": { "playwright": "cli.js" } }, "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg=="],
 
     "@rtsao/scc": ["@rtsao/scc@1.1.0", "", {}, "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g=="],
 
@@ -732,6 +735,8 @@
 
     "fs-extra": ["fs-extra@11.3.4", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA=="],
 
+    "fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
+
     "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
 
     "function.prototype.name": ["function.prototype.name@1.1.8", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.3", "define-properties": "^1.2.1", "functions-have-names": "^1.2.3", "hasown": "^2.0.2", "is-callable": "^1.2.7" } }, "sha512-e5iwyodOHhbMr/yNrc7fDYG4qlbIvI5gajyzPnb5TCwyhjApznQh1BMFou9b30SevY43gCJKXycoCBjMbsuW0Q=="],
@@ -1111,6 +1116,10 @@
     "picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
 
     "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
+
+    "playwright": ["playwright@1.59.1", "", { "dependencies": { "playwright-core": "1.59.1" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw=="],
+
+    "playwright-core": ["playwright-core@1.59.1", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg=="],
 
     "possible-typed-array-names": ["possible-typed-array-names@1.1.0", "", {}, "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg=="],
 

--- a/frontend/e2e/signup.spec.ts
+++ b/frontend/e2e/signup.spec.ts
@@ -1,0 +1,29 @@
+import { test, expect } from '@playwright/test';
+
+test('signup: user can register and redirect to home', async ({ page }) => {
+  // Generate unique email with timestamp suffix to avoid duplicate signup collisions
+  const timestamp = Date.now();
+  const testEmail = `testuser+${timestamp}@example.com`;
+  const testPassword = 'TestPassword123456';
+  const testUsername = `testuser${timestamp % 1000000}`;
+
+  // Navigate to signup page
+  await page.goto('/signup');
+
+  // Fill in all required fields using actual form field IDs
+  await page.fill('#form-signup-firstname', 'Jane');
+  await page.fill('#form-signup-lastname', 'Doe');
+  await page.fill('#form-signup-email', testEmail);
+  await page.fill('#form-signup-username', testUsername);
+  await page.fill('#form-signup-password', testPassword);
+  await page.fill('#form-signup-confirm-password', testPassword);
+
+  // Submit the form by clicking the "Create account" button
+  await page.click('button[form="form-signup"]');
+
+  // Wait for redirect to home page
+  await page.waitForURL('/', { timeout: 30000 });
+
+  // Verify we're on the home page
+  expect(page.url()).toBe('http://localhost:3000/');
+});

--- a/frontend/e2e/signup.spec.ts
+++ b/frontend/e2e/signup.spec.ts
@@ -5,7 +5,8 @@ test('signup: user can register and redirect to home', async ({ page }) => {
   const timestamp = Date.now();
   const testEmail = `testuser+${timestamp}@example.com`;
   const testPassword = 'TestPassword123456';
-  const testUsername = `testuser${timestamp % 1000000}`;
+  // Keep username within backend max_length and reduce collision risk for parallel runs.
+  const testUsername = `testuser${timestamp}`.slice(0, 30);
 
   // Navigate to signup page
   await page.goto('/signup');
@@ -25,5 +26,5 @@ test('signup: user can register and redirect to home', async ({ page }) => {
   await page.waitForURL('/', { timeout: 30000 });
 
   // Verify we're on the home page
-  expect(page.url()).toBe('http://localhost:3000/');
+  expect(new URL(page.url()).pathname).toBe('/');
 });

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,9 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui"
   },
   "dependencies": {
     "@base-ui/react": "^1.4.1",
@@ -32,6 +34,7 @@
     "zod": "^4.3.6"
   },
   "devDependencies": {
+    "@playwright/test": "^1.48.0",
     "@tailwindcss/postcss": "^4.2.4",
     "@types/node": "^25.6.0",
     "@types/react": "^19.2.14",

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,5 +1,7 @@
 import { defineConfig, devices } from '@playwright/test';
 
+const baseURL = process.env.E2E_BASE_URL ?? 'http://localhost:3000';
+
 /**
  * NOTE: The backend server (FastAPI at localhost:8000) must be running manually.
  * Playwright will start the frontend dev server, but the backend is not auto-started.
@@ -14,7 +16,7 @@ export default defineConfig({
   workers: process.env.CI ? 1 : undefined,
   reporter: 'html',
   use: {
-    baseURL: 'http://localhost:3000',
+    baseURL,
     trace: 'on-first-retry',
   },
 
@@ -27,7 +29,7 @@ export default defineConfig({
 
   webServer: {
     command: 'bun run dev',
-    url: 'http://localhost:3000',
+    url: baseURL,
     reuseExistingServer: !process.env.CI,
     timeout: 30000,
   },

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,0 +1,34 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * NOTE: The backend server (FastAPI at localhost:8000) must be running manually.
+ * Playwright will start the frontend dev server, but the backend is not auto-started.
+ * Ensure the backend is running before executing tests.
+ */
+
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: 'html',
+  use: {
+    baseURL: 'http://localhost:3000',
+    trace: 'on-first-retry',
+  },
+
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+
+  webServer: {
+    command: 'bun run dev',
+    url: 'http://localhost:3000',
+    reuseExistingServer: !process.env.CI,
+    timeout: 30000,
+  },
+});


### PR DESCRIPTION
Adds Playwright as a dev dependency and sets up the basic e2e test infrastructure.

- @playwright/test added to frontend devDependencies
- playwright.config.ts: chromium-only, baseURL=localhost:3000, auto-starts frontend dev server, reuses existing server in non-CI
- e2e/signup.spec.ts: one smoke test covering signup flow (fills firstname, lastname, email, username, password, confirm-password and verifies redirect to home)
- bun scripts: test:e2e, test:e2e:ui
- .gitignore updated for test-results, playwright-report, playwright/.cache

To run locally:
1. Start backend manually (Playwright does NOT auto-start it)
2. cd frontend
3. bun install
4. bunx playwright install chromium  (first time only)
5. bun run test:e2e

Backend auto-start, GitHub Actions CI integration, and additional test coverage are scoped as follow-up PRs.