### PR TITLE
adding tests

### DIFF
--- a/frontend/e2e/search.spec.ts
+++ b/frontend/e2e/search.spec.ts
@@ -1,0 +1,31 @@
+import { test, expect } from '@playwright/test';
+
+test('search: user can search listings by query string', async ({ page }) => {
+  // Navigate directly to listings page (no auth required for public listings)
+  await page.goto('/listings');
+
+  // Wait for the navbar search input to be visible
+  const searchInput = page.locator('input[placeholder="Search by location, university..."]');
+  await searchInput.waitFor({ state: 'visible', timeout: 10000 });
+
+  // Type a search query
+  await searchInput.fill('studio');
+
+  // Submit the search by pressing Enter
+  await searchInput.press('Enter');
+
+  // Wait for navigation and verify the URL contains the search query
+  await page.waitForURL('**/listings?q=studio', { timeout: 10000 });
+
+  // Verify the URL has the expected query parameter
+  const url = new URL(page.url());
+  expect(url.searchParams.get('q')).toBe('studio');
+
+  // Verify page has loaded (wait for the main content or ensure no errors)
+  // Either listings are shown or an empty state message is displayed
+  const dashboardContent = page.locator('main, [role="main"]').first();
+  await dashboardContent.waitFor({ state: 'visible', timeout: 10000 });
+
+  // Confirm page is not in a loading or error state
+  expect(page.url()).toContain('studio');
+});

--- a/frontend/e2e/signin.spec.ts
+++ b/frontend/e2e/signin.spec.ts
@@ -1,0 +1,41 @@
+import { test, expect } from '@playwright/test';
+
+test('signin: user can sign in with registered credentials', async ({ page }) => {
+  // Generate unique email with timestamp suffix for a fresh user
+  const timestamp = Date.now();
+  const testEmail = `testuser+${timestamp}@example.com`;
+  const testPassword = 'TestPassword123456';
+  const testUsername = `testuser${timestamp}`.slice(0, 30);
+
+  // First, register a new user via signup
+  await page.goto('/signup');
+  await page.fill('#form-signup-firstname', 'John');
+  await page.fill('#form-signup-lastname', 'Doe');
+  await page.fill('#form-signup-email', testEmail);
+  await page.fill('#form-signup-username', testUsername);
+  await page.fill('#form-signup-password', testPassword);
+  await page.fill('#form-signup-confirm-password', testPassword);
+  await page.click('button[form="form-signup"]');
+
+  // Wait for redirect to home after signup
+  await page.waitForURL('/', { timeout: 30000 });
+
+  // Clear localStorage to force signin flow (removes auth tokens)
+  await page.evaluate(() => localStorage.clear());
+
+  // Navigate to signin page
+  await page.goto('/signin');
+
+  // Fill in signin form with the credentials used during signup
+  await page.fill('#form-signin-email', testEmail);
+  await page.fill('#form-signin-password', testPassword);
+
+  // Submit the signin form
+  await page.click('button[form="form-login"]');
+
+  // Wait for redirect to home page after successful signin
+  await page.waitForURL('/', { timeout: 30000 });
+
+  // Verify we're on the home page
+  expect(new URL(page.url()).pathname).toBe('/');
+});


### PR DESCRIPTION
Adds two more Playwright e2e tests on top of #269.

- e2e/signin.spec.ts: registers a fresh user inline, clears localStorage, signs in via the login form, expects redirect to home
- e2e/search.spec.ts: visits /listings, types in the navbar search input, verifies URL updates with ?q= and the page renders

Each test is self-contained — no shared fixtures.

Note: when running all 3 tests in parallel, the existing signup test (from #269) sometimes fails on the redirect timeout — likely rate limiting since all 3 tests do signups concurrently. Running with `--workers=1` makes everything pass. Worth a follow-up to either add a fixture that uses a single registered account, or run e2e tests serially in CI.